### PR TITLE
smoke: DescartesIterator must return item when hasNext() returns true

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -36,7 +36,7 @@ jobs:
           ${{ runner.os }}-golang-
     - name: Build Contrib
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.49.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.47.3
         make -e DOCKER=false nydusify-release
         make -e DOCKER=false contrib-test
     - name: Upload Nydusify
@@ -116,7 +116,7 @@ jobs:
           export NYDUS_NYDUSIFY_$version_export=/usr/bin/nydus-$version/nydusify
         done
 
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.49.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.47.3
         sudo -E make smoke-only
 
   nydus-unit-test:

--- a/smoke/tests/compatibility_test.go
+++ b/smoke/tests/compatibility_test.go
@@ -63,9 +63,6 @@ func TestCompatibility(t *testing.T) {
 	preparedImages := make(map[string]string)
 	for params.HasNext() {
 		param := params.Next()
-		if param == nil {
-			continue
-		}
 
 		image := param.GetString(paramImage)
 		if _, ok := preparedImages[image]; !ok {

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -75,9 +75,6 @@ func TestImage(t *testing.T) {
 	preparedImages := make(map[string]string)
 	for params.HasNext() {
 		param := params.Next()
-		if param == nil {
-			continue
-		}
 
 		image := param.GetString(paramImage)
 		if _, ok := preparedImages[image]; !ok {

--- a/smoke/tests/native_layer_test.go
+++ b/smoke/tests/native_layer_test.go
@@ -137,9 +137,6 @@ func testNativeLayer(t *testing.T, ctx tool.Context) {
 
 	for params.HasNext() {
 		param := params.Next()
-		if param == nil {
-			continue
-		}
 
 		ctx.Build.Compressor = param.GetString(paramCompressor)
 		ctx.Build.FSVersion = param.GetString(paramFSVersion)

--- a/smoke/tests/tool/iterator.go
+++ b/smoke/tests/tool/iterator.go
@@ -51,19 +51,20 @@ func (d *DescartesItem) Str() string {
 //
 // An example is below:
 //
-//	import (
+//    import (
 //        "fmt"
+//
 //        "github.com/dragonflyoss/image-service/smoke/tests/tool"
 //    )
 //
-//	products := tool.DescartesIterator{}
-//	products.
-//		Register("name", []interface{}{"foo", "imoer", "morgan"}).
-//		Register("age", []interface{}{"20", "30"}).
-//		Skip(func(item *tool.DescartesItem) bool {
+//    products := tool.DescartesIterator{}
+//    products.
+//        Register("name", []interface{}{"foo", "imoer", "morgan"}).
+//        Register("age", []interface{}{"20", "30"}).
+//        Skip(func(item *tool.DescartesItem) bool {
 //            // skip ("morgan", "30")
-//			return item.GetString("name") == "morgan" && param.GetString("age") == "30"
-//		})
+//            return item.GetString("name") == "morgan" && item.GetString("age") == "30"
+//        })
 //
 //    // output:
 //    //       age: 20, name: foo
@@ -71,7 +72,7 @@ func (d *DescartesItem) Str() string {
 //    //       age: 20, name: morgan
 //    //       age: 30, name: foo
 //    //       age: 30, name: imoer
-//    for products.HasNext(){
+//    for products.HasNext() {
 //        item := products.Next()
 //        fmt.Println(item.Str())
 //    }


### PR DESCRIPTION
In order to return Item from `Next()` when `HasNext()` returns true, DescartesIterator stores the information of next item, which involves user-customized `skip()` function. It updates the information when `HasNext` is called and uses the information when `Next()` is called.

Signed-off-by: 泰友 <cuichengxu.ccx@antgroup.com>